### PR TITLE
add flowId to logs

### DIFF
--- a/__tests__/formatter.js
+++ b/__tests__/formatter.js
@@ -1,55 +1,63 @@
 'use strict';
 
+const path = require('path');
 const formatter = require('../lib/formatter');
 const testData = require('./data');
 const consoleOutput = [
-    ["##teamcity[testSuiteStarted name=\'foo/__tests__/file.js\']"],
-    ["##teamcity[testSuiteStarted name=\'path\']"],
-    ["##teamcity[testSuiteStarted name=\'to\']"],
-    ["##teamcity[testSuiteStarted name=\'test1\']"],
-    ["##teamcity[testStarted name=\'title1\']"],
-    ["##teamcity[testFailed name=\'title1\']"],
-    ["##teamcity[testFinished name=\'title1\' duration=\'123\']"],
-    ["##teamcity[testSuiteFinished name=\'test1\']"],
-    ["##teamcity[testSuiteStarted name=\'test2\']"],
-    ["##teamcity[testStarted name=\'title2\']"],
-    ["##teamcity[testIgnored name=\'title2\' message=\'pending\']"],
-    ["##teamcity[testFinished name=\'title2\' duration=\'123\']"],
-    ["##teamcity[testSuiteFinished name=\'test2\']"],
-    ["##teamcity[testSuiteFinished name=\'to\']"],
-    ["##teamcity[testSuiteFinished name=\'path\']"],
-    ["##teamcity[testSuiteFinished name=\'foo/__tests__/file.js\']"],
-    ["##teamcity[testSuiteStarted name=\'foo/__tests__/file2.js\']"],
-    ["##teamcity[testSuiteStarted name=\'path2\']"],
-    ["##teamcity[testSuiteStarted name=\'to\']"],
-    ["##teamcity[testSuiteStarted name=\'test3\']"],
-    ["##teamcity[testStarted name=\'title3\']"],
-    ["##teamcity[testFinished name=\'title3\' duration=\'123\']"],
-    ["##teamcity[testSuiteFinished name=\'test3\']"],
-    ["##teamcity[testSuiteStarted name=\'test4\']"],
-    ["##teamcity[testStarted name=\'title4\']"],
-    ["##teamcity[testFailed name=\'title4\']"],
-    ["##teamcity[testFinished name=\'title4\' duration=\'123\']"],
-    ["##teamcity[testSuiteFinished name=\'test4\']"],
-    ["##teamcity[testSuiteFinished name=\'to\']"],
-    ["##teamcity[testSuiteFinished name=\'path2\']"],
-    ["##teamcity[testSuiteFinished name=\'foo/__tests__/file2.js\']"]
+    ["##teamcity[testSuiteStarted name=\'foo/__tests__/file.js\' flowId=\'12345\']"],
+    ["##teamcity[testSuiteStarted name=\'path\' flowId=\'12345\']"],
+    ["##teamcity[testSuiteStarted name=\'to\' flowId=\'12345\']"],
+    ["##teamcity[testSuiteStarted name=\'test1\' flowId=\'12345\']"],
+    ["##teamcity[testStarted name=\'title1\' flowId=\'12345\']"],
+    ["##teamcity[testFailed name=\'title1\' flowId=\'12345\']"],
+    ["##teamcity[testFinished name=\'title1\' duration=\'123\' flowId=\'12345\']"],
+    ["##teamcity[testSuiteFinished name=\'test1\' flowId=\'12345\']"],
+    ["##teamcity[testSuiteStarted name=\'test2\' flowId=\'12345\']"],
+    ["##teamcity[testStarted name=\'title2\' flowId=\'12345\']"],
+    ["##teamcity[testIgnored name=\'title2\' message=\'pending\' flowId=\'12345\']"],
+    ["##teamcity[testFinished name=\'title2\' duration=\'123\' flowId=\'12345\']"],
+    ["##teamcity[testSuiteFinished name=\'test2\' flowId=\'12345\']"],
+    ["##teamcity[testSuiteFinished name=\'to\' flowId=\'12345\']"],
+    ["##teamcity[testSuiteFinished name=\'path\' flowId=\'12345\']"],
+    ["##teamcity[testSuiteFinished name=\'foo/__tests__/file.js\' flowId=\'12345\']"],
+    ["##teamcity[testSuiteStarted name=\'foo/__tests__/file2.js\' flowId=\'12345\']"],
+    ["##teamcity[testSuiteStarted name=\'path2\' flowId=\'12345\']"],
+    ["##teamcity[testSuiteStarted name=\'to\' flowId=\'12345\']"],
+    ["##teamcity[testSuiteStarted name=\'test3\' flowId=\'12345\']"],
+    ["##teamcity[testStarted name=\'title3\' flowId=\'12345\']"],
+    ["##teamcity[testFinished name=\'title3\' duration=\'123\' flowId=\'12345\']"],
+    ["##teamcity[testSuiteFinished name=\'test3\' flowId=\'12345\']"],
+    ["##teamcity[testSuiteStarted name=\'test4\' flowId=\'12345\']"],
+    ["##teamcity[testStarted name=\'title4\' flowId=\'12345\']"],
+    ["##teamcity[testFailed name=\'title4\' flowId=\'12345\']"],
+    ["##teamcity[testFinished name=\'title4\' duration=\'123\' flowId=\'12345\']"],
+    ["##teamcity[testSuiteFinished name=\'test4\' flowId=\'12345\']"],
+    ["##teamcity[testSuiteFinished name=\'to\' flowId=\'12345\']"],
+    ["##teamcity[testSuiteFinished name=\'path2\' flowId=\'12345\']"],
+    ["##teamcity[testSuiteFinished name=\'foo/__tests__/file2.js\' flowId=\'12345\']"]
 ];
 
 describe('jest-teamcity', () => {
     describe('formatter', () => {
         let consoleFn = console.log;
+        let formatterFn = formatter.log;
 
         beforeAll(() => {
             console.log = jest.fn().mockImplementation(s => s);
+            const formatterMock = path.sep == '/'
+                ? s => formatterFn(s)
+                : s => formatterFn(s.replace(/\\/g, '/'));
+            formatter.log = jest.fn().mockImplementation(formatterMock);
         });
 
         beforeEach(() => {
             console.log.mockReset();
+            formatter.log.mockClear();
         });
 
         afterAll(() => {
             console.log = consoleFn;
+            formatter.log = formatterFn;
         });
 
         describe('escape()', () => {
@@ -74,7 +82,7 @@ test3`)).toEqual('||test|[test2|]|||ntest3');
             });
 
             test('with data', () => {
-                formatter.printTestLog(formatter.collectSuites(testData, '/Users/test'));
+                formatter.printTestLog(formatter.collectSuites(testData, '/Users/test'), '12345');
                 expect(console.log.mock.calls).toEqual(consoleOutput);
             });
         });
@@ -94,8 +102,10 @@ test3`)).toEqual('||test|[test2|]|||ntest3');
             });
 
             test('with result', () => {
+                const fileKey = ['foo', '__tests__', 'file.js'].join(path.sep);
+                const file2Key = ['foo', '__tests__', 'file2.js'].join(path.sep);
                 expect(formatter.collectSuites(testData, '/Users/test')).toEqual({
-                    'foo/__tests__/file.js': {
+                    [fileKey]: {
                         path: expect.objectContaining({
                             to: expect.objectContaining({
                                 test1: expect.any(Object),
@@ -103,7 +113,7 @@ test3`)).toEqual('||test|[test2|]|||ntest3');
                             })
                         }),
                     },
-                    'foo/__tests__/file2.js': {
+                    [file2Key]: {
                         path2: expect.objectContaining({
                             to: expect.objectContaining({
                                 test3: expect.any(Object),
@@ -116,7 +126,7 @@ test3`)).toEqual('||test|[test2|]|||ntest3');
         });
 
         test('formatReport', () => {
-            formatter.formatReport(testData, '/Users/test/');
+            formatter.formatReport(testData, '/Users/test/', '12345');
             expect(console.log.mock.calls).toEqual(consoleOutput);
         });
     });

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -32,38 +32,38 @@ module.exports = {
      * Prints test message
      * @param {object} tests
      */
-    printTestLog(tests) {
+    printTestLog(tests, flowId) {
         if (tests) {
             Object.keys(tests).forEach((suiteName) => {
                 if (suiteName === '_tests_') {
                     // print test details
                     tests[suiteName].forEach((test) => {
-                        this.log(`##teamcity[testStarted name='${this.escape(test.title)}']`);
+                        this.log(`##teamcity[testStarted name='${this.escape(test.title)}' flowId='${flowId}']`);
                         switch (test.status) {
                             case 'failed':
                                 if (test.failureMessages) {
                                     test.failureMessages.forEach((error) => {
                                         const [message, stack] = error.split('\n    ');
-                                        this.log(`##teamcity[testFailed name='${this.escape(test.title)}' message='${this.escape(message)}' details='${this.escape(stack)}']`);
+                                        this.log(`##teamcity[testFailed name='${this.escape(test.title)}' message='${this.escape(message)}' details='${this.escape(stack)}' flowId='${flowId}']`);
                                     });
                                 } else {
-                                    this.log(`##teamcity[testFailed name='${this.escape(test.title)}']`);
+                                    this.log(`##teamcity[testFailed name='${this.escape(test.title)}' flowId='${flowId}']`);
                                 }
 
                                 break;
                             case 'pending':
-                                this.log(`##teamcity[testIgnored name='${this.escape(test.title)}' message='pending']`);
+                                this.log(`##teamcity[testIgnored name='${this.escape(test.title)}' message='pending' flowId='${flowId}']`);
                                 break;
                             case 'passed':
                                 break;
                         }
-                        this.log(`##teamcity[testFinished name='${this.escape(test.title)}' duration='${test.duration}']`);
+                        this.log(`##teamcity[testFinished name='${this.escape(test.title)}' duration='${test.duration}' flowId='${flowId}']`);
                     });
                 } else {
                     // print suite names
-                    this.log(`##teamcity[testSuiteStarted name='${this.escape(suiteName)}']`);
-                    this.printTestLog(tests[suiteName]);
-                    this.log(`##teamcity[testSuiteFinished name='${this.escape(suiteName)}']`);
+                    this.log(`##teamcity[testSuiteStarted name='${this.escape(suiteName)}' flowId='${flowId}']`);
+                    this.printTestLog(tests[suiteName], flowId);
+                    this.log(`##teamcity[testSuiteFinished name='${this.escape(suiteName)}' flowId='${flowId}']`);
                 }
             });
         }
@@ -113,8 +113,8 @@ module.exports = {
      * Formats and outputs tests results
      * @param {array} testResults
      */
-    formatReport(testResults, cwd) {
+    formatReport(testResults, cwd, flowId) {
         const suites = this.collectSuites(testResults, cwd);
-        this.printTestLog(suites);
+        this.printTestLog(suites, flowId);
     }
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,10 +5,11 @@
 'use strict';
 
 const formatter = require('./formatter');
+const flowId = process.env['JEST_TEAMCITY_FLOWID'] || process.pid.toString();
 
 module.exports = (result) => {
     if (process.env.TEAMCITY_VERSION) {
-        formatter.formatReport(result.testResults, process.cwd());
+        formatter.formatReport(result.testResults, process.cwd(), flowId);
     }
 
     return result;

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@
 'use strict';
 
 const formatter = require('./formatter');
-const flowId = process.env['JEST_TEAMCITY_FLOWID'] || process.pid.toString();
+const flowId = process.env['TEAMCITY_FLOWID'] || process.pid.toString();
 
 module.exports = (result) => {
     if (process.env.TEAMCITY_VERSION) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-teamcity",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "Teamcity Reporter for Jest Testing framework",
   "homepage": "https://github.com/itereshchenkov/jest-teamcity",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-teamcity",
-  "version": "2.0.0",
+  "version": "1.4.0",
   "description": "Teamcity Reporter for Jest Testing framework",
   "homepage": "https://github.com/itereshchenkov/jest-teamcity",
   "main": "lib/index.js",


### PR DESCRIPTION
https://www.jetbrains.com/help/teamcity/build-script-interaction-with-teamcity.html#BuildScriptInteractionwithTeamCity-ReportingTests

https://www.jetbrains.com/help/teamcity/build-script-interaction-with-teamcity.html#Message-FlowId

When running tests inside a container (docker 19.03) on TeamCity agent (VM - ubuntu 18.04)
teamcity treats tests as failed. adding flowId helps to solve this issue.