### PR TITLE
Include full stacktrace, not only the first line

### DIFF
--- a/__tests__/data.json
+++ b/__tests__/data.json
@@ -10,7 +10,8 @@
     "testFilePath": "/Users/test/foo/__tests__/file2.js",
     "testResults": [
       { "ancestorTitles": ["path2", "to", "test3"], "title": "title3", "status": "passed", "duration": 123 },
-      { "ancestorTitles": ["path2", "to", "test4"], "title": "title4", "status": "failed", "duration": 123 }
+      { "ancestorTitles": ["path2", "to", "test4"], "title": "title4", "status": "failed", "duration": 123 },
+      { "ancestorTitles": ["path2", "to", "test5"], "title": "title5", "status": "failed", "failureMessages": ["Unexpected exception\n    at path/to/file1.js:1\n    at path/to/file2.js:2"], "duration": 123 }
     ]
   }
 ]

--- a/__tests__/formatter.js
+++ b/__tests__/formatter.js
@@ -32,6 +32,11 @@ const consoleOutput = [
   ["##teamcity[testFailed name='title4' flowId='12345']"],
   ["##teamcity[testFinished name='title4' duration='123' flowId='12345']"],
   ["##teamcity[testSuiteFinished name='test4' flowId='12345']"],
+  ["##teamcity[testSuiteStarted name='test5' flowId='12345']"],
+  ["##teamcity[testStarted name='title5' flowId='12345']"],
+  ["##teamcity[testFailed name='title5' message='Unexpected exception' details='at path/to/file1.js:1|n    at path/to/file2.js:2' flowId='12345']"],
+  ["##teamcity[testFinished name='title5' duration='123' flowId='12345']"],
+  ["##teamcity[testSuiteFinished name='test5' flowId='12345']"],
   ["##teamcity[testSuiteFinished name='to' flowId='12345']"],
   ["##teamcity[testSuiteFinished name='path2' flowId='12345']"],
   ["##teamcity[testSuiteFinished name='foo/__tests__/file2.js' flowId='12345']"]

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -27,6 +27,11 @@ const consoleOutput = [
   ["##teamcity[testFailed name='title4' flowId='12345']"],
   ["##teamcity[testFinished name='title4' duration='123' flowId='12345']"],
   ["##teamcity[testSuiteFinished name='test4' flowId='12345']"],
+  ["##teamcity[testSuiteStarted name='test5' flowId='12345']"],
+  ["##teamcity[testStarted name='title5' flowId='12345']"],
+  ["##teamcity[testFailed name='title5' message='Unexpected exception' details='at path/to/file1.js:1|n    at path/to/file2.js:2' flowId='12345']"],
+  ["##teamcity[testFinished name='title5' duration='123' flowId='12345']"],
+  ["##teamcity[testSuiteFinished name='test5' flowId='12345']"],
   ["##teamcity[testSuiteFinished name='to' flowId='12345']"],
   ["##teamcity[testSuiteFinished name='path2' flowId='12345']"],
   ["##teamcity[testSuiteFinished name='foo/__tests__/file2.js' flowId='12345']"]

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -43,11 +43,12 @@ module.exports = {
               case "failed":
                 if (test.failureMessages) {
                   test.failureMessages.forEach(error => {
-                    const [message, stack] = error.split("\n    ");
+                    const separator = "\n    ";
+                    const [message, ...stack] = error.split(separator);
                     this.log(
                       `##teamcity[testFailed name='${this.escape(test.title)}' message='${this.escape(
                         message
-                      )}' details='${this.escape(stack)}' flowId='${flowId}']`
+                      )}' details='${this.escape(stack.join(separator))}' flowId='${flowId}']`
                     );
                   });
                 } else {


### PR DESCRIPTION
Right now only the first line of the stacktrace is included in `details`