### PR TITLE
Move to Jest reporters API

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Install with npm: `npm install --save-dev jest-teamcity`
 Put this into jest configuration file or package.json
 ```javascript
 "jest": {
-    "testResultsProcessor": "jest-teamcity"
+    "reporters": ["default", "jest-teamcity"]
 }
 ```
 
@@ -29,9 +29,6 @@ To be able to run the tests with the reporter locally, environment variable shou
 ```bash
 export TEAMCITY_VERSION="some_version"
 ```
-
-To enable TeamCity reporter, use the following option:
-`jest --teamcity`
 
 Package.json example:
 ```javascript

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,9 +4,21 @@
 
 const formatter = require("./formatter");
 
-module.exports = result => {
+module.exports = function(result) {
   const flowId = process.env.TEAMCITY_FLOWID || process.pid.toString();
   const teamCityVersion = process.env.TEAMCITY_VERSION;
+
+  // Constructor call means usage as a Jest reporter
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new.target
+  if (new.target) {
+    if (teamCityVersion) {
+      this.onTestResult = (_, result) => {
+        formatter.formatReport([result], process.cwd(), flowId)
+      }
+    }
+
+    return
+  }
 
   if (teamCityVersion) {
     formatter.formatReport(result.testResults, process.cwd(), flowId);


### PR DESCRIPTION
https://jestjs.io/docs/en/configuration#reporters-arraymodulename--modulename-options

Main advantage of `reporters` vs `testResultProcessor` is that `onTestResult` is fired as soon as all tests from a particular test file are finished, so user can see the results earlier.

`testResultProcessor` usage support is kept for backward-compatibility