### PR TITLE
Remove lodash dependency

### DIFF
--- a/__tests__/data.json
+++ b/__tests__/data.json
@@ -11,7 +11,8 @@
     "testResults": [
       { "ancestorTitles": ["path2", "to", "test3"], "title": "title3", "status": "passed", "duration": 123 },
       { "ancestorTitles": ["path2", "to", "test4"], "title": "title4", "status": "failed", "duration": 123 },
-      { "ancestorTitles": ["path2", "to", "test5"], "title": "title5", "status": "failed", "failureMessages": ["Unexpected exception\n    at path/to/file1.js:1\n    at path/to/file2.js:2"], "duration": 123 }
+      { "ancestorTitles": ["path2", "to", "test5"], "title": "title5", "status": "failed", "failureMessages": ["Unexpected exception\n    at path/to/file1.js:1\n    at path/to/file2.js:2"], "duration": 123 },
+      { "ancestorTitles": ["path2", "to", "constructor"], "title": "title6", "status": "passed", "duration": 123 }
     ]
   }
 ]

--- a/__tests__/formatter.js
+++ b/__tests__/formatter.js
@@ -37,6 +37,10 @@ const consoleOutput = [
   ["##teamcity[testFailed name='title5' message='Unexpected exception' details='at path/to/file1.js:1|n    at path/to/file2.js:2' flowId='12345']"],
   ["##teamcity[testFinished name='title5' duration='123' flowId='12345']"],
   ["##teamcity[testSuiteFinished name='test5' flowId='12345']"],
+  ["##teamcity[testSuiteStarted name='constructor' flowId='12345']"],
+  ["##teamcity[testStarted name='title6' flowId='12345']"],
+  ["##teamcity[testFinished name='title6' duration='123' flowId='12345']"],
+  ["##teamcity[testSuiteFinished name='constructor' flowId='12345']"],
   ["##teamcity[testSuiteFinished name='to' flowId='12345']"],
   ["##teamcity[testSuiteFinished name='path2' flowId='12345']"],
   ["##teamcity[testSuiteFinished name='foo/__tests__/file2.js' flowId='12345']"]

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -32,6 +32,10 @@ const consoleOutput = [
   ["##teamcity[testFailed name='title5' message='Unexpected exception' details='at path/to/file1.js:1|n    at path/to/file2.js:2' flowId='12345']"],
   ["##teamcity[testFinished name='title5' duration='123' flowId='12345']"],
   ["##teamcity[testSuiteFinished name='test5' flowId='12345']"],
+  ["##teamcity[testSuiteStarted name='constructor' flowId='12345']"],
+  ["##teamcity[testStarted name='title6' flowId='12345']"],
+  ["##teamcity[testFinished name='title6' duration='123' flowId='12345']"],
+  ["##teamcity[testSuiteFinished name='constructor' flowId='12345']"],
   ["##teamcity[testSuiteFinished name='to' flowId='12345']"],
   ["##teamcity[testSuiteFinished name='path2' flowId='12345']"],
   ["##teamcity[testSuiteFinished name='foo/__tests__/file2.js' flowId='12345']"]

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -109,7 +109,7 @@ module.exports = {
         // find current suite, creating each level if necessary
         let currentSuite = suites;
         for (const p of path) {
-          if (!currentSuite[p]) {
+          if (!Object.prototype.hasOwnProperty.call(currentSuite, p)) {
             currentSuite[p] = {};
           }
           currentSuite = currentSuite[p];

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const _ = require("lodash");
 const path = require("path");
 
 module.exports = {
@@ -105,15 +104,24 @@ module.exports = {
     testResults.forEach(testFile => {
       const filename = path.relative(cwd, testFile.testFilePath);
       testFile.testResults.forEach(test => {
-        const path = [filename].concat(test.ancestorTitles).concat("_tests_");
-        if (!_.has(suites, path)) {
-          _.set(suites, path, []);
+        const path = [filename].concat(test.ancestorTitles);
+
+        // find current suite, creating each level if necessary
+        let currentSuite = suites;
+        for (const p of path) {
+          if (!currentSuite[p]) {
+            currentSuite[p] = {};
+          }
+          currentSuite = currentSuite[p];
         }
 
-        const testsList = _.get(suites, path);
-        testsList.push(test);
+        // last level is array of test results
+        if (!currentSuite["_tests_"]) {
+          currentSuite["_tests_"] = [];
+        }
 
-        _.set(suites, path, testsList);
+        // add the current test
+        currentSuite["_tests_"].push(test);
       });
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2750,7 +2750,8 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
   "description": "Teamcity Reporter for Jest Testing framework",
   "homepage": "https://github.com/itereshchenkov/jest-teamcity",
   "main": "lib/index.js",
-  "dependencies": {
-    "lodash": "^4.17.15"
-  },
+  "dependencies": {},
   "devDependencies": {
     "jest": "^25.1.0",
     "prettier": "^1.19.1"


### PR DESCRIPTION
Fixes #13 by removing the `lodash` dependency and using `Object.prototype.hasOwnProperty` to check for keys in the `suites` object.

Not quite as readable, but it makes this package more resilient to unintended breaking changes in other packages and allows proper reporting of `describe` blocks that use words in the Object prototype chain (such as "constructor").

Closes #14.