### PR TITLE
Fail the suite even if some tests passed

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -124,7 +124,7 @@ module.exports = {
         currentSuite["_tests_"].push(test);
       });
 
-      if (testFile.testExecError && testFile.testResults.length === 0) {
+      if (testFile.testExecError) {
         suites[filename] = suites[filename] || {};
         suites[filename]['_tests_'] = [{
           status: 'failed',


### PR DESCRIPTION
Hi,

Jest can fail a suite if the before/after hooks fail, that was implemented in #16. But that PR was correct only for `before` hooks.

However, it is possible that some/all tests in the suite passes and an `after` hook fails. In that case Jest will populate `testExecError` and `testResults`. The previous PR wasn't accounting for that scenario.